### PR TITLE
change width of circle images

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -678,7 +678,7 @@ td.gutter {
 }
 
 .list-circles-item .item-img {
-  width: 200px;
+  max-width: 200px;
   height: 200px;
   -webkit-border-radius: 50%;
   -moz-border-radius: 50%;


### PR DESCRIPTION
This stops people from looking like monsters because of horizontal stretching. Not everyone will have a perfect circle, but that's better than the alternative.