### PR TITLE
Add pkgdown sites to deployment

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,5 @@
+hugo
+
+# Packages
+rm -rf public/reportfactory
+git clone -b gh-pages https://github.com/reconhub/reportfactory.git public/reportfactory


### PR DESCRIPTION
This change demonstrates how to incorporate a pkgdown site into the hugo build. It is accompanied by a PR in reportfactory https://github.com/reconhub/reportfactory/pull/61

The reportfactory PR builds a pkgdown site on gh-pages whenever there is a push to master. This PR clones the latest gh-pages branches of all noted packages into the public directory for deployment as part of the Hugo process in Netlify. It accomplishes this with a new build script that replaces the default hugo command on Netlify (becomes `.\build.sh`)

The report factory PR needs accepting before this one.